### PR TITLE
Prevent showing incorrect temperature readings

### DIFF
--- a/src/Sensors.ts
+++ b/src/Sensors.ts
@@ -168,7 +168,9 @@ export default class SensorsUtil extends ConsoleUtil {
         ),
       (acc, k) => {
         const value = this.data[k]
-        acc[k] = ConsoleUtil.temperature(value, this.config.temperatureUnit)
+        if (typeof value === 'number' && !isNaN(value)) {
+          acc[k] = ConsoleUtil.temperature(value, this.config.temperatureUnit);
+        }
         return acc
       }
     )


### PR DESCRIPTION
This update ensures that only valid numeric temperature values are displayed.
Previously, some sensors returned invalid or malformed data (e.g., "[object Object]"), which was incorrectly shown in the Thermal widget.
Now, we verify that the sensor value is a valid number before formatting and displaying it, preventing incorrect or confusing information from appearing.

Before the change:
![image](https://github.com/user-attachments/assets/142c989c-f1e2-48c4-95ef-e7b9cd0c5aa3)

After the change:
![image](https://github.com/user-attachments/assets/38dd5c9f-6374-48ff-8081-432567cf0a4e)

