### PR TITLE
docs: clarify lm-sensors hard dependency and ERROR-state troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@
 - `lscpu`
 - `lsblk`
 
+> [!IMPORTANT]
+> `lm-sensors` is a hard dependency. If the `sensors` binary is missing the
+> extension fails to enable with `Error: Util sensors not found` and shows up in
+> the **ERROR** state. Install it first:
+>
+> | Distro | Command |
+> | --- | --- |
+> | Fedora | `sudo dnf install lm_sensors` |
+> | Debian/Ubuntu | `sudo apt install lm-sensors` |
+> | Arch | `sudo pacman -S lm_sensors` |
+>
+> Then run `sudo sensors-detect` once.
+
 
 ## Install
 
@@ -28,6 +41,11 @@ You can clone this repo and build the extension manually with `yarn build:packag
 ## Troubleshooting
 
 - Make sure you have the required dependencies installed and configured
+- **`Error: Util sensors not found` / extension stuck in `ERROR` state** — the
+  `sensors` binary (lm-sensors) is not installed or not in `PATH`. Install
+  `lm-sensors` (see [Requirements](#requirements)), run `sudo sensors-detect`,
+  then re-enable the extension. The same applies if `lscpu` or `lsblk` are
+  missing.
 - Run `./run-log.sh` and check the generated logs `hw.log, err.log`
 - Clone the repo, install dependencies, `yarn dev` and `./run-nested-shell.sh`
 


### PR DESCRIPTION
## What

Documents that `lm-sensors` is a **hard** runtime dependency and explains the failure mode when it is missing.

## Why

When the `sensors` binary is not installed (or not on `PATH`), the extension throws during `enable()`:

```
Extension thinkpadthermal@moonlight.drive.vk.gmail.com: Error: Util sensors not found
  assert@.../extension.js
  ConsoleUtil@.../extension.js
  SensorsUtil@.../extension.js
  ThermalData@.../extension.js
  enable@.../extension.js
```

…and the extension lands in the **ERROR** state. This is easy to misread as a GNOME version incompatibility (e.g. "doesn't work on GNOME 50") when it's actually just a missing dependency. Hit this on a fresh Fedora 44 / GNOME Shell 50 ThinkPad T460 where `lm_sensors` wasn't installed by default.

## Changes

- Add a prominent **IMPORTANT** callout in *Requirements* with per-distro install commands (Fedora / Debian-Ubuntu / Arch) and the `sensors-detect` step.
- Add a *Troubleshooting* entry mapping the exact `Error: Util sensors not found` / ERROR-state symptom to the fix.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)