### PR TITLE
fix: GNOME 50 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "build:package": "yarn clean && rollup -c && yarn package",
-    "copy:dist": "cp -a dist/. ~/.local/share/gnome-shell/extensions/thinkpadthermal@moonlight.drive.vk.gmail.com",
-    "dev": "yarn clean && yarn ts:compile && yarn copy:dist",
+    "copy:dist": "rm -rf ~/.local/share/gnome-shell/extensions/thinkpadthermal@moonlight.drive.vk.gmail.com && cp -a dist ~/.local/share/gnome-shell/extensions/thinkpadthermal@moonlight.drive.vk.gmail.com",
+    "dev": "yarn clean && rollup -c && yarn copy:dist",
     "package": "cd ./dist && zip -qr 'thinkpadthermal@moonlight.drive.vk.gmail.com.zip' . && cd ..",
     "schema:compile": "glib-compile-schemas resources/schemas/",
     "ts:compile": "tsc --build tsconfig.json && cp -a resources/. dist"
@@ -19,8 +19,8 @@
   "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@girs/gjs": "^4.0.0-beta.21",
-    "@girs/gnome-shell": "^47.0.2",
+    "@girs/gjs": "^4.0.4",
+    "@girs/gnome-shell": "^50.0.0",
     "@rollup/plugin-typescript": "^11.1.5",
     "rollup": "^4.2.0",
     "rollup-plugin-copy": "^3.5.0",

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -15,6 +15,7 @@ export default class ConsoleUtil extends GObject.Object {
   }
 
   private _command: string[]
+  protected _destroyed = false
 
   constructor(...args: string[]) {
     super()
@@ -66,6 +67,10 @@ export default class ConsoleUtil extends GObject.Object {
     } catch (e) {
       logError(e)
     }
+  }
+
+  destroy() {
+    this._destroyed = true
   }
 
   get available() {

--- a/src/IbmAcpi.ts
+++ b/src/IbmAcpi.ts
@@ -154,6 +154,8 @@ export default class IbmAcpiUtil extends ConsoleUtil {
     try {
       this.data = await super.execute(this.parse.bind(this))
 
+      if (this._destroyed) return
+
       const diff = microdiff(this.prev, this.data)
       this.prev = this.data
 

--- a/src/Sensors.ts
+++ b/src/Sensors.ts
@@ -69,6 +69,9 @@ export default class SensorsUtil extends ConsoleUtil {
 
     try {
       this.data = await super.execute(this.parse.bind(this))
+
+      if (this._destroyed) return
+
       const obj = SensorsUtil.NOTIFY.reduce((acc, key) => {
         acc[key] = this[key]
         return acc

--- a/src/ThermalData.ts
+++ b/src/ThermalData.ts
@@ -58,6 +58,8 @@ class ThermalData {
       GLib.source_remove(this._interval)
       this._interval = null
     }
+    this.acpi.destroy()
+    this.sensors.destroy()
   }
 }
 

--- a/src/ThermalPopup.ts
+++ b/src/ThermalPopup.ts
@@ -95,7 +95,8 @@ export default class ThermalPopup extends PopupMenu {
       )
 
       Main.panel.statusArea.quickSettings //
-        .addExternalIndicator(this._dd)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .addExternalIndicator(this._dd as any)
     })
 
     acpi.connect('notify::level', (data: IbmAcpiUtil) => {

--- a/src/ThermalUI.ts
+++ b/src/ThermalUI.ts
@@ -47,7 +47,7 @@ export class ButtonSection extends St.BoxLayout {
 
   update(text: string) {
     const [value, unit = ''] = text.split(' ')
-    this._value.set_text(value)
+    this._value.set_text(value ?? '')
     this._unit.set_text(unit)
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,771 +56,641 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz#4c7afa90e3970213599b4095e62f87e5972b2340"
   integrity sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==
 
-"@girs/accountsservice-1.0@1.0.0-4.0.0-beta.20":
-  version "1.0.0-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-4.0.0-beta.20.tgz#fd9b85ac348c5265431d274eeaaa8fb96f55d598"
-  integrity sha512-rIRsbfGpFy9I5aZYj+VtpX+ccGPtUjDJgWCR3WVvnXfXhBLSce5Ap+78YDJUDbnDxiq5zw1u/+dMgnX9sT8fEA==
+"@girs/accountsservice-1.0@^1.0.0-4.0.0-rc.9":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-4.0.0-rc.17.tgz#a2e5751bea36a5dea3fbe1f2eee6606bb3063436"
+  integrity sha512-6kDcrmBKqEeSBBawoyKJvDogT7k9oSnVzgJ8TfAZPRIb4USjFzIt+LJ5PrvGGA9ZvHzNNPoMWbrvyyltU+/Z/Q==
   dependencies:
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/adw-1@^1.7.0-4.0.0-beta.20":
-  version "1.7.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/adw-1/-/adw-1-1.7.0-4.0.0-beta.21.tgz#a975d7b212ca2b4c4a5dbcb01925a10c51494509"
-  integrity sha512-mrfv+5SVqc3R+DllVTNgXe7JioOyv7ONWWKHoWyLO6XNiesQLETOKv5Y0rl1ah+CoXzRd9/j7sWYw0/EFDaXcQ==
+"@girs/adw-1@^1.10.0-4.0.0-rc.9":
+  version "1.10.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/adw-1/-/adw-1-1.10.0-4.0.0-rc.17.tgz#2a17d47c479d2b03fc5684718a2d904fe1596b87"
+  integrity sha512-jNdTKVjdNFMiV7JPimdPudsvkbByeCPkQtiYIemiSwvJ5LQfB48rEf7pYYGBrAtUSBjSUjayWVynGOESNsQ7Bg==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/gsk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gtk-4.0" "^4.17.5-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/gsk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gtk-4.0" "4.23.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/atk-1.0@^2.54.0-4.0.0-beta.20":
-  version "2.54.0-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/atk-1.0/-/atk-1.0-2.54.0-4.0.0-beta.20.tgz#66320be2940de2ff07d42664914889631aa8ad06"
-  integrity sha512-aawHpzC0DTv5DHD1ZVWHBjZEdPYmlPao+CEB2YhHz1xB8CzPcxhTFc5KNcYKKIuj/GA7ZXa2FBduk85lsBlxAQ==
+"@girs/atk-1.0@2.60.0-4.0.0-rc.17", "@girs/atk-1.0@^2.60.0-4.0.0-rc.9":
+  version "2.60.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/atk-1.0/-/atk-1.0-2.60.0-4.0.0-rc.17.tgz#7234d611df84765debdf1e8ac79b1bb0b3acc82d"
+  integrity sha512-Mc4aOlvHCfcE0a0r/vsULbtO4fYDo0SL5dh2F037B/NG/O6ByNn4YLpIdQUnPkO1sY7ViGb4HY/aCtWcPZIcdA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/atk-1.0@^2.55.2-4.0.0-beta.21":
-  version "2.55.2-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/atk-1.0/-/atk-1.0-2.55.2-4.0.0-beta.21.tgz#c6d916723fb739d3690932785f22055be28ad21a"
-  integrity sha512-S9QJS2xfqADiIq3bhNH7QXlKQL3R/9nJCvbiDXwXtSpLcV0V4MhZUL3CDIC7tpxbF8SESTYhgZ0lygkCarzHpA==
+"@girs/cairo-1.0@1.0.0-4.0.0-rc.17":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.17.tgz#68562f01fd94c87553f258f17af8388c3774c09c"
+  integrity sha512-CAR/TbYfxWq+pJl7H7s4dG6zH3KN1LUYy+YAFFmaopFJEaLheMN9j84gX+VsF23UwZvKVZH+PX5qk6LSrBdWjg==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/cairo-1.0@^1.0.0-4.0.0-beta.20":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.21.tgz#d5fa723ac48ee0bd12b7ed1b3dac8d37695899be"
-  integrity sha512-hdtk26K7yTQiyGXBHlhvq5zO+PZKE5wvs8ckpgueM5E+2rLgnTrGWJDDm7CtWqPsDju3JpqjQ2xhXP/4dIpOQg==
+"@girs/cairo-1.0@1.0.0-4.0.4":
+  version "1.0.0-4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz#b08b2be0eb276011624b245146894033de500032"
+  integrity sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.4"
+    "@girs/glib-2.0" "2.88.0-4.0.4"
+    "@girs/gobject-2.0" "2.88.0-4.0.4"
 
-"@girs/cairo-1.0@^1.0.0-4.0.0-beta.21", "@girs/cairo-1.0@^1.0.0-4.0.0-beta.23":
-  version "1.0.0-4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.23.tgz#4762f2d78b725ad051c0db9fcc4d224b896d7dc6"
-  integrity sha512-t5fADO+9TmZy8Xzk6Fqk23B3bmakzhNQxa3kFERzy2cL8p1q1pAWm1ARNcadIsl2IbflS4Hbn5sAwRwOm8W67A==
+"@girs/clutter-18@18.0.0-4.0.0-rc.17", "@girs/clutter-18@^18.0.0-4.0.0-rc.9":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/clutter-18/-/clutter-18-18.0.0-4.0.0-rc.17.tgz#8e03984ad278e5e8994e3d8aa301ad693dc76def"
+  integrity sha512-Tea+UB/JjCmlfYmH5BvX/EayKKkcRssjaVYVhlW7EYdk1/rU2MRzhyB/MYcS/OMt3aKZFgJU4wdmD+pB2807Og==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.23"
-    "@girs/glib-2.0" "^2.84.0-4.0.0-beta.23"
-    "@girs/gobject-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/atk-1.0" "2.60.0-4.0.0-rc.17"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/cogl-18" "18.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/mtk-18" "18.0.0-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
 
-"@girs/cally-15@^15.0.0-4.0.0-beta.20":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/cally-15/-/cally-15-15.0.0-4.0.0-beta.21.tgz#4d889ee6c082aee15c97215476f8bee83a5f2c52"
-  integrity sha512-1uvF3jvXMWUW0JWzYEJVXFA6n7s4IX1a1dNI9tT73qZ/VFuU4jk8kiby0FNLbvadmGrWhthUR2gPb9fpCt9vHA==
+"@girs/cogl-18@18.0.0-4.0.0-rc.17":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/cogl-18/-/cogl-18-18.0.0-4.0.0-rc.17.tgz#4833ae3ac0d7d6360d2e14f0511120bcf793127c"
+  integrity sha512-EK0/yMoKGgFlje/jcGduF3nNgz6wj0rR3xNvfBTTIAG3Sf25EBw1UzqMZCpwsp+4nxexSJKxQgdJ05YxNnC1WQ==
   dependencies:
-    "@girs/atk-1.0" "^2.55.2-4.0.0-beta.21"
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/clutter-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/coglpango-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/mtk-18" "18.0.0-4.0.0-rc.17"
 
-"@girs/clutter-15@^15.0.0-4.0.0-beta.20", "@girs/clutter-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/clutter-15/-/clutter-15-15.0.0-4.0.0-beta.21.tgz#77c0c31c6985ca9065093b6b0575f0ed11fcff17"
-  integrity sha512-W06UwTMdu6nPshSml6GhLmBlZ52Q7rZa7C9tj5LFLRdZG+yzX04ci8JjkdR/D7QtSh3qM49ibKzYmWUzA//YpA==
+"@girs/cogl-2.0@^2.0.0-4.0.0-rc.9":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/cogl-2.0/-/cogl-2.0-2.0.0-4.0.0-rc.17.tgz#c4da0de126cc445983e76394bd6bd688741830f4"
+  integrity sha512-C9TcbrfzEOXlD0XpM5S+bNB2mPGDQKGwGcxDH1Y7sBlL6EEzdGnFquIiTh0M5HnH3pJEwtpec+U/Az9eYyMIYA==
   dependencies:
-    "@girs/atk-1.0" "^2.55.2-4.0.0-beta.21"
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/coglpango-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/cogl-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/cogl-15/-/cogl-15-15.0.0-4.0.0-beta.21.tgz#351a7f504459ee2776598fd558f89ac95d4673a1"
-  integrity sha512-wxPxN7XFtCPVWIvbDZ4la/AV7LzZNiFxgJ1/v6C8b8rZspSTnY9LSRlbUAeLqkcKefY7FyqdVWPbliepQVNBMg==
+"@girs/freetype2-2.0@2.0.0-4.0.0-rc.17":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.17.tgz#01b761614a7a309966fb2fa0356fa096c60c571e"
+  integrity sha512-llJxKidMOX8HDcKXVg051EPQ08BFOeIcYSnUlLzLETWDE5mZv+slXTfH6k5cZX+5VH66fJvOoBALXl/MebkbCA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/cogl-2.0@^2.0.0-4.0.0-beta.20":
-  version "2.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/cogl-2.0/-/cogl-2.0-2.0.0-4.0.0-beta.21.tgz#6ea939acbc3eae1056597d5abb1ee3df448261da"
-  integrity sha512-5J2k9mEjbVvUKzRH6MgfT3tQKo9JUbLzbcJWviokvrUn0s7DFpRIf/7PzTvWMscwHL8SjFATBYtUlynSWgg9+w==
+"@girs/gck-2@4.4.0-4.0.0-rc.17":
+  version "4.4.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gck-2/-/gck-2-4.4.0-4.0.0-rc.17.tgz#8d6586d585844887922df92614e324b20188d1ae"
+  integrity sha512-l382BN5YD4gXfoHuG7yvhYH87B6yw+qKdxToWLlJWV6L8LJFCqaSMg+Ezn+nKC+czRxb/57YhOIRp39wzoZiGA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/coglpango-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/coglpango-15/-/coglpango-15-15.0.0-4.0.0-beta.21.tgz#ad45a6824769e394bf3468d0a0a80eb0e40d0eee"
-  integrity sha512-bjjFSq/Q8y9CHlDHdHF7wNwUIWmNo9v1CUI2h1JlvG3MpogaGSiHeDDj7Wnc0hTXZVlQ2Q4M30i+AlHZat2CTw==
+"@girs/gcr-4@4.4.0-4.0.0-rc.17", "@girs/gcr-4@^4.4.0-4.0.0-rc.9":
+  version "4.4.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gcr-4/-/gcr-4-4.4.0-4.0.0-rc.17.tgz#8befc5332cd8001294d728f3e66d02171208057c"
+  integrity sha512-QX3BI9Oq8Zwmhbxb/1UfJ6E0GWC3gCQObxMTxbNPlSWACXdHtTwBON1tEh29TwkyEOvuIfdHXSMrJjV+iQdK+A==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
+    "@girs/gck-2" "4.4.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/freetype2-2.0@^2.0.0-4.0.0-beta.20", "@girs/freetype2-2.0@^2.0.0-4.0.0-beta.21":
-  version "2.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.21.tgz#39012ccc75b12616d1dc15e22d0474008dee4d39"
-  integrity sha512-ADqnPTm1SQnA1E2ZkP2FjdhtIv04wWsaUTy5Em75RlHXs0z/4YGHSocHCmd7Om1PEHsSRLkd44soEzhfIl4rQA==
+"@girs/gdesktopenums-3.0@3.0.0-4.0.0-rc.17":
+  version "3.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gdesktopenums-3.0/-/gdesktopenums-3.0-3.0.0-4.0.0-rc.17.tgz#f907b16f32ea943d2e38aa228c953c092e1c5630"
+  integrity sha512-MJJyJQb9dTtVUe54NJ9Y+jq5VqI7gnf25SWrbw5QbHeswDEvUP8Blt1+cii9nKJncADbpEkHnOFeNw0BLio7uw==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gck-2@^4.3.0-4.0.0-beta.20":
-  version "4.3.0-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/gck-2/-/gck-2-4.3.0-4.0.0-beta.20.tgz#b18efd4f2a07d17f9b2517da1b2945d97ccf3d8b"
-  integrity sha512-sPSmtwNSdumBG+wnG+502aBjllk3fArVHr4m9ZvTUoitLD6p1Ht+Z+7DR71ae/tC7ZAk0lBr5k/s18i23KNi8g==
+"@girs/gdk-4.0@4.0.0-4.0.0-rc.17":
+  version "4.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-rc.17.tgz#b5b90096abc26133f1c740b5b41f3170f3bf2331"
+  integrity sha512-1UPtr5LfLn558R3tXADVJV9vDWc3rQRwSvC0C8gr2/NesRbTb/O7r95ikgxKGDD6MwV8fW+zrMSGBJwtvwifHg==
   dependencies:
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/gck-2@^4.3.91-4.0.0-beta.21":
-  version "4.3.91-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gck-2/-/gck-2-4.3.91-4.0.0-beta.21.tgz#74edfa5c60237b7aea78276cad0dd4507d12ee5e"
-  integrity sha512-G0EPPq4sLfFPPMhAu/8sKVude9N4g9lC+2Mmoss0xc1MYxp0y8UpeusJzPkojxihHK1iv+ca7/3ggp2zS1qWFw==
+"@girs/gdkpixbuf-2.0@2.0.0-4.0.0-rc.17":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.17.tgz#073caf78a1a9e884da2160f4f6aa3d42f4b31d14"
+  integrity sha512-vezXIM2WFni7f/IxslMvd1RFk/zJj6YNO0yrSfAShtqF1u8hxUvJc4p0S6Ve2RYh0cRBD1WZRYvK91OlnA1VXg==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gcr-4@^4.3.0-4.0.0-beta.20":
-  version "4.3.0-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/gcr-4/-/gcr-4-4.3.0-4.0.0-beta.20.tgz#35b82def6b52c9c359717e1bbad3c1ff371a1d72"
-  integrity sha512-PMacRxe2ebTLqyFThBthlIXRu5RXpFG9gBbxOMUbp9ifb9P1lglvpmS0UoI8MDcRZAN5HagULqvt68/vpe9huA==
+"@girs/gdm-1.0@^1.0.0-4.0.0-rc.9":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gdm-1.0/-/gdm-1.0-1.0.0-4.0.0-rc.17.tgz#5774854e2da3758e3ce1966d175a66f49b922dc9"
+  integrity sha512-jUW8J8UWiGa5q3tshvqDiCNRr6Hs5zAWDNtIfVBWvOI4Lgi2iw6hxzMZsjqUN8IwZs1/gj/DMbWG9clB/g17Bw==
   dependencies:
-    "@girs/gck-2" "^4.3.0-4.0.0-beta.20"
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gcr-4@^4.3.91-4.0.0-beta.21":
-  version "4.3.91-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gcr-4/-/gcr-4-4.3.91-4.0.0-beta.21.tgz#52a4d1254f9f49073a32669855a2685cd726dd45"
-  integrity sha512-ym2foWEMBvRTGj/SUhtYcFykYDndnHwxVaYk4/XHPgmc53E6/yLh/d99d5kjtsgo9sTO1rrFSRtgaQIzozaDRw==
+"@girs/gio-2.0@2.88.0-4.0.0-rc.17", "@girs/gio-2.0@^2.88.0-4.0.0-rc.9":
+  version "2.88.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.17.tgz#10257db5a41551ee4c7ee331a79d3838c5770404"
+  integrity sha512-OkyK3LvTjgaRIiySxZdDdOM07BFRzy7SRPj1J4YbMSZpqmkpWRhmeq7uZoZCLqQxAQk4MUdAOp17XiUGZFpibg==
   dependencies:
-    "@girs/gck-2" "^4.3.91-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gdesktopenums-3.0@^3.0.0-4.0.0-beta.21":
-  version "3.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gdesktopenums-3.0/-/gdesktopenums-3.0-3.0.0-4.0.0-beta.21.tgz#d6e5434d86180cf00f5701a09928906cbe1b27dc"
-  integrity sha512-2z4/XT6o1laDQW3+RFSjPSGk+FxESd6wnrJLrzeMuP/1d2CajTuH2pgynNei3q8gFWwzfm2abt5OY/dmq03wMg==
+"@girs/gio-2.0@2.88.0-4.0.4":
+  version "2.88.0-4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz#6ecdf68560140885e7b6188a70297aa7fc203085"
+  integrity sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.4"
+    "@girs/glib-2.0" "2.88.0-4.0.4"
+    "@girs/gmodule-2.0" "2.0.0-4.0.4"
+    "@girs/gobject-2.0" "2.88.0-4.0.4"
 
-"@girs/gdk-4.0@^4.0.0-4.0.0-beta.20", "@girs/gdk-4.0@^4.0.0-4.0.0-beta.21":
-  version "4.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.21.tgz#b68a287509543cdce418fa55ac3ab3fa7d2aff4a"
-  integrity sha512-ddJEKon+DEkI/6cLa4ao6J/J0A8fbBSQPVZGQbz6efVur53WuGHU+RcP+8cpI63nugNKIxYI3We/b0VpU/NFfQ==
+"@girs/giounix-2.0@2.0.0-4.0.0-rc.17", "@girs/giounix-2.0@^2.0.0-4.0.0-rc.9":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/giounix-2.0/-/giounix-2.0-2.0.0-4.0.0-rc.17.tgz#66ad07ba61df3ef1fb7dffad68c2f672a41f52b9"
+  integrity sha512-bS3SdZ0LCHa+mGJYw+JNly7TqjQM5xlhdxKfnHgvwS5XzY+6Ko8sIq2ozi76Pho/cz5TJPigbxuW6OywxqqHFw==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gdkpixbuf-2.0@^2.0.0-4.0.0-beta.20", "@girs/gdkpixbuf-2.0@^2.0.0-4.0.0-beta.21":
-  version "2.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.21.tgz#29c933e59fda31e07bc6f5e7eead7cc7df8054fb"
-  integrity sha512-KEux+GDYgycqoy3oQhGDkHW7ll3wPBfCFZu00W7RKmBg8Z3mrB7CgMtETHu7eQ/SWELD26TXJ/YoTAiF7R3fTQ==
+"@girs/gjs@4.0.0-rc.17":
+  version "4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gjs/-/gjs-4.0.0-rc.17.tgz#9b00759ba15802eed5c69797630516f6e51cb86e"
+  integrity sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gdm-1.0@^1.0.0-4.0.0-beta.20":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gdm-1.0/-/gdm-1.0-1.0.0-4.0.0-beta.21.tgz#c342ae323105ad24d43670ee0ba2f3594e8594bc"
-  integrity sha512-7APNXSBBLrRAaPlMtgzGlKnSBOjTsc4cffcOzO5ttGCT/swG8kx5DrkBBVMe8TM5zoPO9HId7t7SH1CxLbAJuA==
+"@girs/gjs@4.0.4", "@girs/gjs@^4.0.0-rc.9", "@girs/gjs@^4.0.4":
+  version "4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gjs/-/gjs-4.0.4.tgz#e20891614ae4735b6113706f767bcbeca740b179"
+  integrity sha512-Tgp5Jt3wenLcevB5n+DdH/jWmrRAgnL9ERvqRpiz3hup+NHdHDLp4HrlhyUqoEr37qknA3+El210bQdxbm5FuA==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.4"
+    "@girs/gio-2.0" "2.88.0-4.0.4"
+    "@girs/glib-2.0" "2.88.0-4.0.4"
+    "@girs/gobject-2.0" "2.88.0-4.0.4"
 
-"@girs/gio-2.0@^2.82.4-4.0.0-beta.20":
-  version "2.82.4-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/gio-2.0/-/gio-2.0-2.82.4-4.0.0-beta.20.tgz#b4dc0d896c290fc5089939ab732e1d4e8e89eae5"
-  integrity sha512-w9Bu0uLv0ikSgXwnS/Gtsf+daOZBoMy+uD8lWAam4trq8rfYAfPUCGhFwhUqnkcF6TsF5+5z4N9RZADS4+IRqg==
+"@girs/gl-1.0@1.0.0-4.0.0-rc.17":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gl-1.0/-/gl-1.0-1.0.0-4.0.0-rc.17.tgz#2a1fa145adc22fcee1f8ac96b8d9d09307cc7411"
+  integrity sha512-2radfaX9jOKQ06yyXS5f7bjTXcWvYRP+bAQsxqyqm3/2wOjyfT+XnMRKfj5tUu6yCPXUXBix2jVwNANibWcZBA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gio-2.0@^2.83.3-4.0.0-beta.21":
-  version "2.83.3-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gio-2.0/-/gio-2.0-2.83.3-4.0.0-beta.21.tgz#0b87d473503d13022d72436d8926b46b23bd5ca1"
-  integrity sha512-vMnWFjFNzyRvEkLOFo8d5VMcE+XOzEpy5PEZPpWYUj4JtIgSKrhVmeIiHaZ+UhiNwsXcDDBqmgoPL9Jo+bMR0A==
+"@girs/glib-2.0@2.88.0-4.0.0-rc.17", "@girs/glib-2.0@^2.88.0-4.0.0-rc.9":
+  version "2.88.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.17.tgz#6380f5bc5a66ee8f606231073633204131b5f50a"
+  integrity sha512-nTZBcDY++60wLo2OfrOWAYe7Lw9BRVIEIwiQ+7CieDAzgBgpMs1QE2xY3xwfUHEBIyzsDSZMd2DW4afHXtkz3g==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gio-2.0@^2.84.0-4.0.0-beta.23":
-  version "2.84.0-4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/gio-2.0/-/gio-2.0-2.84.0-4.0.0-beta.23.tgz#456d7cb2037b07698ed3513b19ff8bbb21e5206a"
-  integrity sha512-FcGgYQ96KhdeFJvUYsIm0XmOYaYnTfpHKzPUOW4IcJm5q38RNDKgoijBMfedv3fMxnPDtpMb08ZFD6P1GjJY8A==
+"@girs/glib-2.0@2.88.0-4.0.4":
+  version "2.88.0-4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz#22f533c9cc719d5878ce9f0e60b32e15d7c98fa5"
+  integrity sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.23"
-    "@girs/glib-2.0" "^2.84.0-4.0.0-beta.23"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.23"
-    "@girs/gobject-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/gjs" "4.0.4"
+    "@girs/gobject-2.0" "2.88.0-4.0.4"
 
-"@girs/gjs@^4.0.0-beta.20":
-  version "4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gjs/-/gjs-4.0.0-beta.21.tgz#e61d86d0c7d3ffb7e5b6daab4d7f56174ec754a4"
-  integrity sha512-qXnChkcpYG6vZjJpGMsDcMmypZnwSDR0FS69d5rpi/vv9bQePs6iVl0o+lyp/n8gr8YrPKijRL32CRsOdq+taQ==
+"@girs/gmodule-2.0@2.0.0-4.0.0-rc.17":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.17.tgz#261bfd93e6c7cccfa726fdd1a0ce1e307d152e58"
+  integrity sha512-47UwefN6gjqWSZRrYLGnQumVAsughnu+gHBuDkeB4ZZCPZko4AiAb+G/WB6tTWdAy08pm+tLvlQ1vjP1eN9bQQ==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gjs@^4.0.0-beta.21", "@girs/gjs@^4.0.0-beta.23":
-  version "4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/gjs/-/gjs-4.0.0-beta.23.tgz#d14e021d61586c77cddd82cc0429d4f9e166a8a7"
-  integrity sha512-Yz1s23WaGAsVHetWFReVxeYDJbVFtJ6KZ7u+qzWa/B3P2mB+5aXpGc7nV6Bx7GbRc48FuGgtbKxVo0rq26Ug/Q==
+"@girs/gmodule-2.0@2.0.0-4.0.4":
+  version "2.0.0-4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz#9dc9eceb5e3f48670b99e2e039bb2a8545c6ccd3"
+  integrity sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.23"
-    "@girs/gio-2.0" "^2.84.0-4.0.0-beta.23"
-    "@girs/glib-2.0" "^2.84.0-4.0.0-beta.23"
-    "@girs/gobject-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/gjs" "4.0.4"
+    "@girs/glib-2.0" "2.88.0-4.0.4"
+    "@girs/gobject-2.0" "2.88.0-4.0.4"
 
-"@girs/gl-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gl-1.0/-/gl-1.0-1.0.0-4.0.0-beta.21.tgz#256e0acae6d18a1976b5b406ddfc1918f087779a"
-  integrity sha512-dKVTBcWWl2xIHbdqsrjx3rRC3R8xucCpfiOohP0qRBrYDVQZhovpYM4cXPemahSoHZXKCoFJoq9s6UArRP5x4Q==
+"@girs/gnome-shell@^50.0.0":
+  version "50.0.0"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gnome-shell/-/gnome-shell-50.0.0.tgz#ed147e21f9b45c7fcbd29cd4b1bc9670f6cc4bff"
+  integrity sha512-ki3VBO/WUvinGRB8lSPa6Rn0qJwEs3cQOvZa/P8MzM/68mujLPy453qVT6fwyMPqHVusAv3JZuj9HnUewx1GeQ==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/accountsservice-1.0" "^1.0.0-4.0.0-rc.9"
+    "@girs/adw-1" "^1.10.0-4.0.0-rc.9"
+    "@girs/atk-1.0" "^2.60.0-4.0.0-rc.9"
+    "@girs/clutter-18" "^18.0.0-4.0.0-rc.9"
+    "@girs/cogl-2.0" "^2.0.0-4.0.0-rc.9"
+    "@girs/gcr-4" "^4.4.0-4.0.0-rc.9"
+    "@girs/gdm-1.0" "^1.0.0-4.0.0-rc.9"
+    "@girs/gio-2.0" "^2.88.0-4.0.0-rc.9"
+    "@girs/giounix-2.0" "^2.0.0-4.0.0-rc.9"
+    "@girs/gjs" "^4.0.0-rc.9"
+    "@girs/glib-2.0" "^2.88.0-4.0.0-rc.9"
+    "@girs/gnomebg-4.0" "^4.0.0-4.0.0-rc.9"
+    "@girs/gnomebluetooth-3.0" "^3.0.0-4.0.0-rc.9"
+    "@girs/gnomedesktop-4.0" "^4.0.0-4.0.0-rc.9"
+    "@girs/gobject-2.0" "^2.88.0-4.0.0-rc.9"
+    "@girs/gtk-4.0" "^4.23.0-4.0.0-rc.9"
+    "@girs/gvc-1.0" "^1.0.0-4.0.0-rc.9"
+    "@girs/meta-18" "^18.0.0-4.0.0-rc.9"
+    "@girs/mtk-18" "^18.0.0-4.0.0-rc.9"
+    "@girs/polkit-1.0" "^1.0.0-4.0.0-rc.9"
+    "@girs/shell-18" "^18.0.0-4.0.0-rc.9"
+    "@girs/shew-0" "^0.0.0-4.0.0-rc.9"
+    "@girs/st-18" "^18.0.0-4.0.0-rc.9"
+    "@girs/upowerglib-1.0" "^1.91.1-4.0.0-rc.9"
 
-"@girs/glib-2.0@^2.82.4-4.0.0-beta.20":
-  version "2.82.4-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/glib-2.0/-/glib-2.0-2.82.4-4.0.0-beta.20.tgz#2f37234cf86149a9631c02493addaf50ab015b47"
-  integrity sha512-A2iRZH1Y8f7Ma+VgjiZb+9aVAy9XeD3J+68aEBIF9GylsjuFwCGTAVmIRkn/d+wsKqh4Ml87enKv2Dygk5PzRg==
+"@girs/gnomebg-4.0@^4.0.0-4.0.0-rc.9":
+  version "4.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gnomebg-4.0/-/gnomebg-4.0-4.0.0-4.0.0-rc.17.tgz#1244ddee6c7e2e0d11f7fef63d55f032e7a45728"
+  integrity sha512-lucIrA5lv9ga6RQYvlMXK196fCneXAYgyX1/nRL9hTSsSvNDPczOwrPOfhvI/oOFmJTfR1tXq18UqAc1XcTpgA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdesktopenums-3.0" "3.0.0-4.0.0-rc.17"
+    "@girs/gdk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gnomedesktop-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/glib-2.0@^2.83.3-4.0.0-beta.21":
-  version "2.83.3-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/glib-2.0/-/glib-2.0-2.83.3-4.0.0-beta.21.tgz#9b272cc76c01f2f5fc7d368eb7cf52eee889b84a"
-  integrity sha512-PmH6CVqfWFlFSbiffoRO4QmC4vsiJCznzFHuH5FrNMjOvH8OsTC+8wl+dtVXtmyhzXPOs2/jrTC5Ikx+gqK2ZQ==
+"@girs/gnomebluetooth-3.0@^3.0.0-4.0.0-rc.9":
+  version "3.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gnomebluetooth-3.0/-/gnomebluetooth-3.0-3.0.0-4.0.0-rc.17.tgz#f2e35dea1fc79229aedb616ec1fe3a754e254818"
+  integrity sha512-6Ky3o26G5Xnbq/wg51siQEljBlB4sNrWpfYOsl9lch7eAtupNBqWbVm/Dxd4G0B2iXkmMLPSPOSahyTyW5HMiA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/glib-2.0@^2.84.0-4.0.0-beta.23":
-  version "2.84.0-4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/glib-2.0/-/glib-2.0-2.84.0-4.0.0-beta.23.tgz#e2d2efeb8227499914bdd96fa3a0a39aa5e84fbd"
-  integrity sha512-epQae3f9rDeIrEgA9hOEiNAppJYQAfVRZ4Uh/0yO9NtAQR6PTfXUpjotw9ndjVxsHpEmRODoM2t/kytCYqKmVg==
+"@girs/gnomedesktop-4.0@4.0.0-4.0.0-rc.17", "@girs/gnomedesktop-4.0@^4.0.0-4.0.0-rc.9":
+  version "4.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gnomedesktop-4.0/-/gnomedesktop-4.0-4.0.0-4.0.0-rc.17.tgz#9d8e72b3362e2109d279dba0fe9ce987f20bda30"
+  integrity sha512-xiJ5sYqnrJ7iGD9DRq01v6ylf2kjjgxBt3lAa/+zUfSYiq5TERJ1WHbXkJXDWiqNhEGntQ/NTfeCWDqBtWkVDQ==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.23"
-    "@girs/gobject-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/gdesktopenums-3.0" "3.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gmodule-2.0@^2.0.0-4.0.0-beta.20":
-  version "2.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.21.tgz#e47319e784528cebe19e995b22d109ea551b9406"
-  integrity sha512-NmhqahN13eTvDhUFbIj/i2wuOlGjKECv3GqD5gN7uZuWgyom3YslJEhQC7rjUAMdXssgT9LIBexLCLpePfBm0Q==
+"@girs/gobject-2.0@2.88.0-4.0.0-rc.17", "@girs/gobject-2.0@^2.88.0-4.0.0-rc.9":
+  version "2.88.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.17.tgz#8a680cbe01d7466bf8f530aa3d5b64d42a17299d"
+  integrity sha512-pUkGnIrYVgRzFLWJSXU+pwWpWzrTCzbDeZLu1QzxpBT0n/t5HJnIGX3PYBnQSvXbBgVFXoSOt1pOfB7m8J2agQ==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gmodule-2.0@^2.0.0-4.0.0-beta.21", "@girs/gmodule-2.0@^2.0.0-4.0.0-beta.23":
-  version "2.0.0-4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.23.tgz#d550bea19e9d5ccc7bb82a61d0942f7410a5d15d"
-  integrity sha512-Dc+Pq1peNlwQ0o/WFsUzT1qt3oqgMLBhzjEfOTGAD0Jw1Ut3QCoBuryVFFNMIruOKnSSBoBnQO7Qelly5aSd2w==
+"@girs/gobject-2.0@2.88.0-4.0.4":
+  version "2.88.0-4.0.4"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz#9b21e3723b8d7c9bd09747e247a92f515144c6f8"
+  integrity sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.23"
-    "@girs/glib-2.0" "^2.84.0-4.0.0-beta.23"
-    "@girs/gobject-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/gjs" "4.0.4"
+    "@girs/glib-2.0" "2.88.0-4.0.4"
 
-"@girs/gnome-shell@^47.0.2":
-  version "47.0.2"
-  resolved "https://registry.yarnpkg.com/@girs/gnome-shell/-/gnome-shell-47.0.2.tgz#de59ca2212e5fe4c284d17ea07a5644c72a4c2bb"
-  integrity sha512-FoZeL0t1OZB+wvoaAEm6iC5wwEh63vr8Xihe57o0/u6914tmKq1htmvZf++xGvTsNmvL3ezagFH2AoYwAypfBA==
+"@girs/graphene-1.0@1.0.0-4.0.0-rc.17":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-rc.17.tgz#0cef46838c165334366cc2060bda11e608eb54bb"
+  integrity sha512-9+b0ApjMsG8Pq2bLyug3mE4lO3cFNqoEvtQIl3z50cXz/4alpPI+GdBL9C/SeiqMiEK+x3RbPsFXm7r/epkGDg==
   dependencies:
-    "@girs/accountsservice-1.0" "1.0.0-4.0.0-beta.20"
-    "@girs/adw-1" "^1.7.0-4.0.0-beta.20"
-    "@girs/atk-1.0" "^2.54.0-4.0.0-beta.20"
-    "@girs/cally-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/clutter-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/cogl-2.0" "^2.0.0-4.0.0-beta.20"
-    "@girs/gcr-4" "^4.3.0-4.0.0-beta.20"
-    "@girs/gdm-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gnomebg-4.0" "^4.0.0-4.0.0-beta.20"
-    "@girs/gnomebluetooth-3.0" "^3.0.0-4.0.0-beta.20"
-    "@girs/gnomedesktop-4.0" "^4.0.0-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gtk-4.0" "^4.16.12-4.0.0-beta.20"
-    "@girs/gvc-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/meta-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/polkit-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/shell-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/shew-0" "^0.0.0-4.0.0-beta.20"
-    "@girs/st-15" "^15.0.0-4.0.0-beta.20"
-    "@girs/upowerglib-1.0" "^0.99.1-4.0.0-beta.20"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gnomebg-4.0@^4.0.0-4.0.0-beta.20":
-  version "4.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gnomebg-4.0/-/gnomebg-4.0-4.0.0-4.0.0-beta.21.tgz#026dfa49c081c5ba26c753af978a8bcb538b29f8"
-  integrity sha512-PduyZ9UHTb6BWnpVSYaRDnusjXJxcCmy5MzGCXRQwohtuecYlP4NQp3Iptgf/LcJzJie/nM/ULmTKDmPV0Vf+Q==
+"@girs/gsk-4.0@4.0.0-4.0.0-rc.17":
+  version "4.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-rc.17.tgz#c4749706f95bd182550603c4760f1f09e7eb1422"
+  integrity sha512-NztZASK0Lahi2whus75NeVOOl/RcJRjswVY9HDCZjO38KoFWIO8rt1aT0z5Dw8YXscnNhkkbQcMh+myWq0yHuw==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdesktopenums-3.0" "^3.0.0-4.0.0-beta.21"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gnomedesktop-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/gnomebluetooth-3.0@^3.0.0-4.0.0-beta.20":
-  version "3.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gnomebluetooth-3.0/-/gnomebluetooth-3.0-3.0.0-4.0.0-beta.21.tgz#916d0ea925f708ac95c00547113e8da49dbe5ad5"
-  integrity sha512-G0ikLOqBYETPaNsXfnOmsVKRneiYGXsqkXHb5V/UUueUsQ3rthd4ZNUOdDJYS4YIU1BZo18Z2lKRKMxHLgAoZQ==
+"@girs/gtk-4.0@4.23.0-4.0.0-rc.17", "@girs/gtk-4.0@^4.23.0-4.0.0-rc.9":
+  version "4.23.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.0-rc.17.tgz#840627629a66816ac0a669530ba2ffc0a16515ea"
+  integrity sha512-tbX3nR68/n6BhhePMJHjIp9gSHfM+noyUjpx+4Pd1VImbEWjfZKqn92+X9zQZWyD6rgmaRu0CRGbD3z5ecNMcA==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/gsk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/gnomedesktop-4.0@^4.0.0-4.0.0-beta.20", "@girs/gnomedesktop-4.0@^4.0.0-4.0.0-beta.21":
-  version "4.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gnomedesktop-4.0/-/gnomedesktop-4.0-4.0.0-4.0.0-beta.21.tgz#8d8d58e435ea019d111a870f0cbbe4a5b20500bb"
-  integrity sha512-P+3H/MUPAkyaiSLGVlAtxBnjhCZhO1I9sOL5m+v3NgM7wTBv+sNu8wqeTlSFzxAyMCfdM3tfp7uN/gvOhe7xSQ==
+"@girs/gvc-1.0@1.0.0-4.0.0-rc.17", "@girs/gvc-1.0@^1.0.0-4.0.0-rc.9":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/gvc-1.0/-/gvc-1.0-1.0.0-4.0.0-rc.17.tgz#225b383172c23e37a41e4a13621d5078f29b2ec6"
+  integrity sha512-KTf7RhTgz+C0AwIEK/rDixvLzxmmYyUCmNSIlnWN1Ct2OKt9wRAPESPJIqb4AOOvJkDkm7XYlP4pQKuk7iF2OQ==
   dependencies:
-    "@girs/gdesktopenums-3.0" "^3.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gobject-2.0@^2.82.4-4.0.0-beta.20":
-  version "2.82.4-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/gobject-2.0/-/gobject-2.0-2.82.4-4.0.0-beta.20.tgz#c78c2073f12c71fcc9689ec29eb8cbae2b9399d6"
-  integrity sha512-4Lpo7znbxz/1Gugw98/lfU5Avk6NUFzBAEOscuWIeYvrLO5+axMj2Ksm0ldldjTqdomihLfeaLesuObbe+0h1g==
+"@girs/harfbuzz-0.0@13.2.1-4.0.0-rc.17":
+  version "13.2.1-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.17.tgz#ffaaf94c127381612f7ffb43e8fc11baaa0ad59c"
+  integrity sha512-sefFHkbo++qj7Fbt9l6VmAhHtGFvVoQEyIsfQtsWLCURj2A4YCcBMvFhD2IZRSEBE6ZxyIvxszyzauintFcVlg==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gobject-2.0@^2.83.3-4.0.0-beta.21":
-  version "2.83.3-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gobject-2.0/-/gobject-2.0-2.83.3-4.0.0-beta.21.tgz#a06fd608c29000dc6a88b90b8ff1488a3abda390"
-  integrity sha512-K5mWozEeQpR6GcWwF27fqFp5E4YjCgdGA1atXJhT8eE3F6DW6yQ1khn2SYiTTY3StVWN2fjov+WsiEcWPJNILg==
+"@girs/meta-18@18.0.0-4.0.0-rc.17", "@girs/meta-18@^18.0.0-4.0.0-rc.9":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/meta-18/-/meta-18-18.0.0-4.0.0-rc.17.tgz#0796a53244cc9542a6c1053b16bef7be26be2543"
+  integrity sha512-1bNDgyt2MJuv/K0byQklGLSYXljUddZQEwYeQU7+ZJKRX/9yT8JIx71Vcn1kjFIgU4/jAJIbqKwplrEoZ/cTQA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/atk-1.0" "2.60.0-4.0.0-rc.17"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/clutter-18" "18.0.0-4.0.0-rc.17"
+    "@girs/cogl-18" "18.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdesktopenums-3.0" "3.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/mtk-18" "18.0.0-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/xfixes-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/xlib-2.0" "2.0.0-4.0.0-rc.17"
 
-"@girs/gobject-2.0@^2.84.0-4.0.0-beta.23":
-  version "2.84.0-4.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@girs/gobject-2.0/-/gobject-2.0-2.84.0-4.0.0-beta.23.tgz#67b0859f94795adab4092b822ca803d82df3b38c"
-  integrity sha512-GNWQDLo+Nmq2FQNPljKKh4Zplp8vZwwr0hj1sf4lbJ36zbVsovrhfNozqaph0XNjv8vtHeTcXUocGQprM9FHCg==
+"@girs/mtk-18@18.0.0-4.0.0-rc.17", "@girs/mtk-18@^18.0.0-4.0.0-rc.9":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/mtk-18/-/mtk-18-18.0.0-4.0.0-rc.17.tgz#920f669af5efea7388b2239485c7ceadb5bcb2d2"
+  integrity sha512-ioFpaXxj97QfxiGFq9vuUwzzwSs0AjCNfZopqbklhpk43jvK3A4DPVrfxdTwpAXK1+ig6mByBHrFL1tp3VXe8Q==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.23"
-    "@girs/glib-2.0" "^2.84.0-4.0.0-beta.23"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/graphene-1.0@^1.0.0-4.0.0-beta.20", "@girs/graphene-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.21.tgz#b76c41052c3600699a06573171854123d8827f6a"
-  integrity sha512-qlGXGAYsLt1cZwRduR/uf/uZDze2nXMAi9e3PYA4gYYm9f1SlRHvyqY4dj/DWiwR2TJPrY47STxmuzCMGVx7IQ==
+"@girs/nm-1.0@1.56.0-4.0.0-rc.17":
+  version "1.56.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/nm-1.0/-/nm-1.0-1.56.0-4.0.0-rc.17.tgz#16a041bacd9cdaa0ed80bf8d363fcfc77543dafe"
+  integrity sha512-Xu9wViW0WuEL9kp5wl0ybVVQCiJ6DbMjGibg48mE6aWq336jE/GYvEBdGr/VjSsmP3k1KtehKB3BqHIz4DXq7w==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gsk-4.0@^4.0.0-4.0.0-beta.20", "@girs/gsk-4.0@^4.0.0-4.0.0-beta.21":
-  version "4.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.21.tgz#30646dc68530be2b1bf316a682f68548a368aa5c"
-  integrity sha512-cGJeUKhBtyoFUezuDjhbhjePiW6H9w0CfHCIqoZmWzrhpd4MhHrQ3nvkht+bxC4ddEcZwzayT+yCw+w0BNEtcA==
+"@girs/pango-1.0@1.57.1-4.0.0-rc.17":
+  version "1.57.1-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.17.tgz#1b5b42bf6f667a73b08cb50520354e2c03e887d6"
+  integrity sha512-bsYFe06tlIAcqcKK8ALOBOzIs04sgTIturR0tGyeC1bxwPPU+2VTeHDarRMbG7tCq9U1B6hCSHzPaT1Z94onHg==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
 
-"@girs/gtk-4.0@^4.16.12-4.0.0-beta.20":
-  version "4.16.12-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/gtk-4.0/-/gtk-4.0-4.16.12-4.0.0-beta.20.tgz#4be2b12ec1095b258cd06238ba784df32a4c2601"
-  integrity sha512-7SmTJNPAKQAOKVu6OSSY4S38U8EMWDbStyOGdT1raCgRecdV98dFnqbb+vYZQ7EB7tRMioF73jcoXVS9kqBAVg==
+"@girs/pangocairo-1.0@1.0.0-4.0.0-rc.17":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.17.tgz#76944f6431651a92ed0d7680cda4aa7c518bb294"
+  integrity sha512-f6NfgDiNJVnRCa4QVBa4hvkGs0cVVfTqy1chvxfN95YjLLeO9rmlYlpqPoonN39ttM+HuEG0X4IuQoY1yG3zxw==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.20"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.20"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.20"
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/gsk-4.0" "^4.0.0-4.0.0-beta.20"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.20"
-    "@girs/pango-1.0" "^1.54.0-4.0.0-beta.20"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.20"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
 
-"@girs/gtk-4.0@^4.17.5-4.0.0-beta.21":
-  version "4.17.5-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gtk-4.0/-/gtk-4.0-4.17.5-4.0.0-beta.21.tgz#9b4e7d70702239f1ecc734c4d42804b1adf482b7"
-  integrity sha512-qLKd7mJsA1e3Gba+NcXR6nhGrHMa7DjVNxCigRXkDvWjk+fY7BqPv03wSqTLP+GoGkFVIxbcPllV1q/mnirM/w==
+"@girs/polkit-1.0@1.0.0-4.0.0-rc.17", "@girs/polkit-1.0@^1.0.0-4.0.0-rc.9":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/polkit-1.0/-/polkit-1.0-1.0.0-4.0.0-rc.17.tgz#0f6fbf16f8642f359fba19040371e2566b11f2e8"
+  integrity sha512-JCPnI7b6NPByEsmERKDnVOCbvsSpApJM2nPkcoibJD+YZR/s0xZsTU0gOAWYGGRvtTSDxovoSc0IY9KpLCxu4g==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/gsk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/gvc-1.0@^1.0.0-4.0.0-beta.20", "@girs/gvc-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/gvc-1.0/-/gvc-1.0-1.0.0-4.0.0-beta.21.tgz#11c872a4d206564249d88a98c9b692916a83e6f8"
-  integrity sha512-FDEGPqiRHio10m4VFgiKjeWX4kRNHBq/S4nhqs0gAcYSbzyswVZpdffdYIhMTPhguNELh8/27oWwtR5FrTCTPQ==
+"@girs/polkitagent-1.0@1.0.0-4.0.0-rc.17":
+  version "1.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/polkitagent-1.0/-/polkitagent-1.0-1.0.0-4.0.0-rc.17.tgz#1d5d085b9435a11a675f8831d9b99760439f0ec1"
+  integrity sha512-5k/rJQY2GoamqED02ljM0f4He0vR5ubuHd21H4VNv/2q3TA1vfbR8aid8B+1dLTNCbOabeNeJa8RLL5fZm8/cA==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/polkit-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/harfbuzz-0.0@^9.0.0-4.0.0-beta.20", "@girs/harfbuzz-0.0@^9.0.0-4.0.0-beta.21":
-  version "9.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/harfbuzz-0.0/-/harfbuzz-0.0-9.0.0-4.0.0-beta.21.tgz#9086e8837c2c35082a8fa84652664f89760fc1ad"
-  integrity sha512-0xv+n89lA0beWUF9+8TF1PHnjZ/IOtTdtGwD8yU9msStMiFJ0+NMDeU2X3aU6i9EVn5NK2VsyfwIZEw/wGrkgg==
+"@girs/shell-18@^18.0.0-4.0.0-rc.9":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/shell-18/-/shell-18-18.0.0-4.0.0-rc.17.tgz#664f9508a55c1d3328de99f830400261a4350ed3"
+  integrity sha512-jerEw69d0VqNkKgDi14T111/vIlhDfNKeiH0My/xRvodIAFD/4Xfjeod4N+GpUUNydt+OWuI3gk2MPb7aSSlYA==
   dependencies:
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/atk-1.0" "2.60.0-4.0.0-rc.17"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/clutter-18" "18.0.0-4.0.0-rc.17"
+    "@girs/cogl-18" "18.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gck-2" "4.4.0-4.0.0-rc.17"
+    "@girs/gcr-4" "4.4.0-4.0.0-rc.17"
+    "@girs/gdesktopenums-3.0" "3.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/giounix-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/gvc-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/meta-18" "18.0.0-4.0.0-rc.17"
+    "@girs/mtk-18" "18.0.0-4.0.0-rc.17"
+    "@girs/nm-1.0" "1.56.0-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/polkit-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/polkitagent-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/st-18" "18.0.0-4.0.0-rc.17"
+    "@girs/xfixes-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/xlib-2.0" "2.0.0-4.0.0-rc.17"
 
-"@girs/meta-15@^15.0.0-4.0.0-beta.20", "@girs/meta-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/meta-15/-/meta-15-15.0.0-4.0.0-beta.21.tgz#ab03ad5137631a50e0e6e3010542444b4b859230"
-  integrity sha512-xn09egMW9b41gZykRGuoiO/LPrhgnJMVmfMDqmt5yE3ImqkwdKY2FNk4MM/qGKhRCov4uC4LZiz8BpGjt6QHIA==
+"@girs/shew-0@^0.0.0-4.0.0-rc.9":
+  version "0.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/shew-0/-/shew-0-0.0.0-4.0.0-rc.17.tgz#13ef8a73632ab2ba7c15f9e7f45bddc7981f8664"
+  integrity sha512-YUzSrTT7euZufSXGDRMfxICWf0056TgwFr9P+0c9BdUAhFuCzlPv17/ozeCE/f1Rj2QNHS/THbwSCGrlmv62sg==
   dependencies:
-    "@girs/atk-1.0" "^2.55.2-4.0.0-beta.21"
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/clutter-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/coglpango-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdesktopenums-3.0" "^3.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/xfixes-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/gsk-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/gtk-4.0" "4.23.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/pangocairo-1.0" "1.0.0-4.0.0-rc.17"
 
-"@girs/mtk-15@^15.0.0-4.0.0-beta.20", "@girs/mtk-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/mtk-15/-/mtk-15-15.0.0-4.0.0-beta.21.tgz#4d95c43d4d8b4a85abe5dabbe95fa644769f35c2"
-  integrity sha512-u5G5t+e8eyjshcfldXouRE9e/7k4vqNFRXvqhd68bFDsj2PG/jZ2umlusC0/82mVGOBwXUkZgcpbzVEKw5qhfA==
+"@girs/st-18@18.0.0-4.0.0-rc.17", "@girs/st-18@^18.0.0-4.0.0-rc.9":
+  version "18.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/st-18/-/st-18-18.0.0-4.0.0-rc.17.tgz#d80b0eeafd97a33a5f6155d5818993903ed74ef6"
+  integrity sha512-Qtj7ECDtQ6EcdY+sPe/ZY7aCIy7ZnXgQmxiqb2uJyjPZw9/P/7MJnZTDxb51OeWUkwWdyBcCWylA6yCsypLduA==
   dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
+    "@girs/atk-1.0" "2.60.0-4.0.0-rc.17"
+    "@girs/cairo-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/clutter-18" "18.0.0-4.0.0-rc.17"
+    "@girs/cogl-18" "18.0.0-4.0.0-rc.17"
+    "@girs/freetype2-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gdesktopenums-3.0" "3.0.0-4.0.0-rc.17"
+    "@girs/gdkpixbuf-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gl-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/graphene-1.0" "1.0.0-4.0.0-rc.17"
+    "@girs/harfbuzz-0.0" "13.2.1-4.0.0-rc.17"
+    "@girs/meta-18" "18.0.0-4.0.0-rc.17"
+    "@girs/mtk-18" "18.0.0-4.0.0-rc.17"
+    "@girs/pango-1.0" "1.57.1-4.0.0-rc.17"
+    "@girs/xfixes-4.0" "4.0.0-4.0.0-rc.17"
+    "@girs/xlib-2.0" "2.0.0-4.0.0-rc.17"
 
-"@girs/nm-1.0@^1.49.4-4.0.0-beta.21":
-  version "1.49.4-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/nm-1.0/-/nm-1.0-1.49.4-4.0.0-beta.21.tgz#c14efce90dca4773776f01ae56569d04b0019cb3"
-  integrity sha512-+ng0kkPtPF/9UciJwwmOMIcNSfW4r0Gi6LcktyZdUOZqanKEGzjUGv9OWn2H7za9kyIcNyUaIv6bVwknUPAjBQ==
+"@girs/upowerglib-1.0@^1.91.1-4.0.0-rc.9":
+  version "1.91.1-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/upowerglib-1.0/-/upowerglib-1.0-1.91.1-4.0.0-rc.17.tgz#669ace5a0a95cd42248a8ebcbec539e8787b67fb"
+  integrity sha512-mbJeKrndak2azRWrBlnv9rh46OgszLF94yB+UKjfUQJILmRMwLSVA3IDQtVMJpOPSOnU/0HIoFIuUHk3t5PDcg==
   dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gio-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/glib-2.0" "2.88.0-4.0.0-rc.17"
+    "@girs/gmodule-2.0" "2.0.0-4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/pango-1.0@^1.54.0-4.0.0-beta.20":
-  version "1.54.0-4.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@girs/pango-1.0/-/pango-1.0-1.54.0-4.0.0-beta.20.tgz#b8bba3afb6a55ef44b7568a1940b3d3d8c39dd9e"
-  integrity sha512-OrJ1syhT+18H6Y455IT54WI3E/CCRrPCAben5ygmlpappkfNz4voVCofVegBk0zGutXgbORtkYm3+0Wt1IuGHg==
+"@girs/xfixes-4.0@4.0.0-4.0.0-rc.17":
+  version "4.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/xfixes-4.0/-/xfixes-4.0-4.0.0-4.0.0-rc.17.tgz#f8afa8e1be246ecc9ec37b8a338b143c78d2bee8"
+  integrity sha512-kWgv5+PskncaS2rWfibkzT6UzBYYoSjygApRr/ptF3Yp6jW+NSltgak32F338JPlEAE4mRenqMljpx1740d1Sg==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.20"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.20"
-    "@girs/gio-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gjs" "^4.0.0-beta.20"
-    "@girs/glib-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/gobject-2.0" "^2.82.4-4.0.0-beta.20"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.20"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
-"@girs/pango-1.0@^1.56.0-4.0.0-beta.21":
-  version "1.56.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/pango-1.0/-/pango-1.0-1.56.0-4.0.0-beta.21.tgz#5a3fb702ebbbbfd1c86c129153e66372f680329f"
-  integrity sha512-x6YfqTJ6NlBpq2ScVIAeWOWGyec0DUCCA0vT6FwpeVgi0XjV0JB9gBDvSrw/t9cmL1ge6ImVZqYfCfr+d6K0ow==
+"@girs/xlib-2.0@2.0.0-4.0.0-rc.17":
+  version "2.0.0-4.0.0-rc.17"
+  resolved "https://npm.stibo.dk/repository/tim/@girs/xlib-2.0/-/xlib-2.0-2.0.0-4.0.0-rc.17.tgz#bb92ad06ae2565d0e55d95c13bdcc657b7a50b5f"
+  integrity sha512-LaECgnppICePEdVOYvXSvUFe8V8NUvDp0aNDRHCSA9VmqzPVNQWcik4UI/75wNOp4Mz5I8N6XkM0PGZzPgpObA==
   dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-
-"@girs/pangocairo-1.0@^1.0.0-4.0.0-beta.20", "@girs/pangocairo-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.21.tgz#73639a0e3911c086b6424bafc01d4ced4e8bc014"
-  integrity sha512-VeW3k3bb1J5Ub8AkJZsZcovFIKZqOg5M5Pf7Ayu/z9y4m05pdrnyk89Dh/W82Ps0TNnRXIMPb1sPWQoCGhLXKQ==
-  dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-
-"@girs/polkit-1.0@^1.0.0-4.0.0-beta.20", "@girs/polkit-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/polkit-1.0/-/polkit-1.0-1.0.0-4.0.0-beta.21.tgz#da15838208ff4b12e8cfc3ab6392e799dbceddcc"
-  integrity sha512-kV3ncgRPar/Ky3um5x/ERFF9nlvrM90HjmBSm618uca5C5Q+NpLKjKKEyLPyhwpqNsPgbTN2prR/OcIIuAWHPA==
-  dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-
-"@girs/polkitagent-1.0@^1.0.0-4.0.0-beta.21":
-  version "1.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/polkitagent-1.0/-/polkitagent-1.0-1.0.0-4.0.0-beta.21.tgz#3f6cfd8bfa1a0dfd221b9c878794aee03a934997"
-  integrity sha512-4gcDBQ1GwfVtu76KxaDXRE2lLgmwBKo0wL11bPihcRp5sRic1cEqSzcpGg1dGZq0KRiOAz19ffgeEVr2QQZCLw==
-  dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/polkit-1.0" "^1.0.0-4.0.0-beta.21"
-
-"@girs/shell-15@^15.0.0-4.0.0-beta.20":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/shell-15/-/shell-15-15.0.0-4.0.0-beta.21.tgz#b49d7e8acec877cc667670f732da1c4182854165"
-  integrity sha512-9KNj9L1deBxCAvEDvOx2RCQ834GwsSXCsLt50AMZMqSMRf02wJ4zxbG6ygG681/mpCt9SPF9KKCOMgTxqfcdHw==
-  dependencies:
-    "@girs/atk-1.0" "^2.55.2-4.0.0-beta.21"
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/clutter-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/coglpango-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gck-2" "^4.3.91-4.0.0-beta.21"
-    "@girs/gcr-4" "^4.3.91-4.0.0-beta.21"
-    "@girs/gdesktopenums-3.0" "^3.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/gvc-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/meta-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/nm-1.0" "^1.49.4-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/polkit-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/polkitagent-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/st-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/xfixes-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
-
-"@girs/shew-0@^0.0.0-4.0.0-beta.20":
-  version "0.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/shew-0/-/shew-0-0.0.0-4.0.0-beta.21.tgz#8e6d128abc41fbe2563c840f83700c7064d5b42a"
-  integrity sha512-/z3Vgt6ly+MKYHV+5neMm5ZjzGH1LFNK4+MZlL9zZE/nnYjlG7NRUQK45vwnfQoPApb3hOLlMU2nBUlDnRjBFQ==
-  dependencies:
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/gsk-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/gtk-4.0" "^4.17.5-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-
-"@girs/st-15@^15.0.0-4.0.0-beta.20", "@girs/st-15@^15.0.0-4.0.0-beta.21":
-  version "15.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/st-15/-/st-15-15.0.0-4.0.0-beta.21.tgz#2d2187f749d3bc1caf950ab14155d212c3870901"
-  integrity sha512-ddAmpmWNGco1UsSvoTpEp8EwcRfDmWNrN2ld95N2Z+XUGHPXIvXASbp9I+jo9oFo78mwHQJe2PHQaQT6UpbHiQ==
-  dependencies:
-    "@girs/atk-1.0" "^2.55.2-4.0.0-beta.21"
-    "@girs/cairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/clutter-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/cogl-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/coglpango-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/freetype2-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gdesktopenums-3.0" "^3.0.0-4.0.0-beta.21"
-    "@girs/gdkpixbuf-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gl-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/graphene-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/harfbuzz-0.0" "^9.0.0-4.0.0-beta.21"
-    "@girs/meta-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/mtk-15" "^15.0.0-4.0.0-beta.21"
-    "@girs/pango-1.0" "^1.56.0-4.0.0-beta.21"
-    "@girs/pangocairo-1.0" "^1.0.0-4.0.0-beta.21"
-    "@girs/xfixes-4.0" "^4.0.0-4.0.0-beta.21"
-    "@girs/xlib-2.0" "^2.0.0-4.0.0-beta.21"
-
-"@girs/upowerglib-1.0@^0.99.1-4.0.0-beta.20":
-  version "0.99.1-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/upowerglib-1.0/-/upowerglib-1.0-0.99.1-4.0.0-beta.21.tgz#88111ecdc54dbcd4dcff0b9c03f03c5a0579d56b"
-  integrity sha512-WrpvjCxNqd3FI1mquKsmJAcsPk6kfwv7huKxkBomd1O6nbuuoOmoE61fT43uwElk4yyvB2Qk2SYUg5tOKYRMfA==
-  dependencies:
-    "@girs/gio-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/glib-2.0" "^2.83.3-4.0.0-beta.21"
-    "@girs/gmodule-2.0" "^2.0.0-4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-
-"@girs/xfixes-4.0@^4.0.0-4.0.0-beta.21":
-  version "4.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/xfixes-4.0/-/xfixes-4.0-4.0.0-4.0.0-beta.21.tgz#9d7c42cb409b5609465a6fa7b0bfe4f63b481f4d"
-  integrity sha512-kLvg2C0y0d7J+bHE61zhSy5nC0m9yFGVKc6+mcvDnF++e76Zpb/nXYGObIs8iVkNSwynFPybSPZm6Ltd+Urrlg==
-  dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
-
-"@girs/xlib-2.0@^2.0.0-4.0.0-beta.21":
-  version "2.0.0-4.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@girs/xlib-2.0/-/xlib-2.0-2.0.0-4.0.0-beta.21.tgz#08bfec98510bcb15e31e4e2e0ce49ddf39c5a1b8"
-  integrity sha512-M4gE8DixPcrYfoOYke4GSa2o3JsRjQvPtNtFbluqfszaz/nLqJJ1aCr+vVJyO4oahERJJfzVuB26jztEeJ/oqg==
-  dependencies:
-    "@girs/gjs" "^4.0.0-beta.21"
-    "@girs/gobject-2.0" "^2.83.3-4.0.0-beta.21"
+    "@girs/gjs" "4.0.0-rc.17"
+    "@girs/gobject-2.0" "2.88.0-4.0.0-rc.17"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
## Summary

- **Fix use-after-free crash on disable/enable** — async subprocess callbacks (`Gio.Subprocess.communicate_utf8_async`) could fire after the extension was disabled, trying to update disposed `St.BoxLayout` objects. GNOME 50 ships with GJS 1.82 which added stricter object lifecycle enforcement that turned this pre-existing race into a hard crash. Fixed by adding a `_destroyed` flag to `ConsoleUtil` that `IbmAcpiUtil` and `SensorsUtil` check after each `await` before emitting any signals. `ThermalData.destroy()` now propagates to `acpi` and `sensors`.
- **Update TypeScript types to GNOME 50** — bumped `@girs/gnome-shell` from `^47.0.2` → `^50.0.0` and `@girs/gjs` to `^4.0.4` to resolve a `@girs/gobject-2.0` version conflict that caused numerous spurious `GObject.registerClass` type errors under rollup.
- **Fix `set_text` type** — GNOME 50 types require `string | null`; added `?? ''` to the `string | undefined` from array destructuring.
- **Fix `addExternalIndicator` cast** — the GNOME 50 `@girs` type definition incorrectly types the parameter as `PanelMenu.Button` instead of `SystemIndicator`; the runtime API is unchanged so a cast is sufficient.
- **Fix `dev` build script** — use `rollup` bundle instead of raw `tsc` output so the installed extension is a single bundled `extension.js` as expected.

## Test plan

- [x] `yarn install && rollup -c` completes with no TypeScript errors (only a benign circular-dependency warning)
- [x] Extension installs to `~/.local/share/gnome-shell/extensions/thinkpadthermal@moonlight.drive.vk.gmail.com/`
- [x] GNOME Shell reports `state: ENABLED, error: ''` via `org.gnome.Shell.Extensions.GetExtensionInfo`
- [x] No "already disposed" errors in `journalctl --user` after repeated disable/enable cycles
- [x] Tested on GNOME Shell 50.2 (Fedora 44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)